### PR TITLE
GoTimeParser: Utility for converting a Golang Duration string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
                 <artifactId>bcpkix-jdk15on</artifactId>
                 <version>1.56</version>
             </dependency>
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>2.10.5</version>
+            </dependency>
 
             <!-- Dependencies not needed at runtime -->
             <dependency>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -45,5 +45,10 @@
             <artifactId>bcpkix-jdk15on</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/sdk/src/main/java/com/hashicorp/nomad/javasdk/GoTimeParser.java
+++ b/sdk/src/main/java/com/hashicorp/nomad/javasdk/GoTimeParser.java
@@ -1,0 +1,60 @@
+package com.hashicorp.nomad.javasdk;
+
+import org.joda.time.MutablePeriod;
+import org.joda.time.format.PeriodFormatterBuilder;
+import org.joda.time.format.PeriodParser;
+
+import java.util.Locale;
+
+/**
+ * Utility for converting a Golang Duration string to a Long.
+ * Supports units: h (hour), m (minute), s (second), ms (milliseconds)
+ * Similar to: https://golang.org/pkg/time/#ParseDuration
+ *
+ * Note: Specifying units out of order (Example: 10s5m) will result in an error
+ */
+public class GoTimeParser {
+
+    private static final Long NANOSECONDS_PER_SECOND = 1_000_000_000L;
+    private static final Long SECONDS_PER_MINUTE = 60L;
+    private static final Long MINUTES_PER_HOUR = 60L;
+    private static final Long MILLISECONDS_PER_SECOND = 1000L;
+    private PeriodParser periodParser;
+
+    /**
+     * Initializes the parser.
+     */
+    public GoTimeParser() {
+        periodParser = new PeriodFormatterBuilder()
+            .rejectSignedValues(true)
+            .appendHours()
+            .appendSuffix("h")
+            .appendMinutes()
+            .appendSuffix("m")
+            .appendSeconds()
+            .appendSuffix("s")
+            .appendMillis()
+            .appendSuffix("ms")
+            .toParser();
+    }
+
+    /**
+     * Converts a Golang Duration string to a Long.
+     * @param time Golang style duration string (Example: 1h10m)
+     *             Note: specifying units out of order is unsupported (Example: 10s5m)
+     * @return Number of nanoseconds equal to the duration
+     * @throws IllegalArgumentException on parsing failure
+     */
+    public Long toNanoSeconds(String time) {
+        MutablePeriod period = new MutablePeriod();
+        int parseResult = periodParser.parseInto(period, time, 0, Locale.ENGLISH);
+        if ((parseResult <= 0) ||  parseResult < time.length()) {
+            throw new IllegalArgumentException("Failed to parse: " + time + ", error at position: " + parseResult);
+        }
+
+        return period.getHours() * MINUTES_PER_HOUR * SECONDS_PER_MINUTE * NANOSECONDS_PER_SECOND
+            + period.getMinutes() * SECONDS_PER_MINUTE * NANOSECONDS_PER_SECOND
+            + period.getSeconds() * NANOSECONDS_PER_SECOND
+            + period.getMillis() * MILLISECONDS_PER_SECOND;
+    }
+}

--- a/sdk/src/test/java/com/hashicorp/nomad/javasdk/GoTimeParserTest.java
+++ b/sdk/src/test/java/com/hashicorp/nomad/javasdk/GoTimeParserTest.java
@@ -1,0 +1,45 @@
+package com.hashicorp.nomad.javasdk;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GoTimeParserTest {
+
+    private static GoTimeParser target;
+    private static final Long NANOS_PER_SECOND = 1_000_000_000L;
+
+    @BeforeClass
+    public static void setUp() {
+        target = new GoTimeParser();
+    }
+
+    @Test
+    public void testCommonTimeStrings() {
+        assertThat(target.toNanoSeconds("1s"), is(NANOS_PER_SECOND));
+        assertThat(target.toNanoSeconds("1m"), is(60 * NANOS_PER_SECOND));
+        assertThat(target.toNanoSeconds("1h"), is(3600 * NANOS_PER_SECOND));
+    }
+
+    @Test
+    public void testTwoTimeUnits() {
+        assertThat(target.toNanoSeconds("1m30s"), is(90 * NANOS_PER_SECOND));
+    }
+
+    @Test
+    public void testAllTimeUnits() {
+        assertThat(target.toNanoSeconds("1h10m5s500ms"), is(4205_000_500_000L));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnitsOutOfOrder() {
+        target.toNanoSeconds("10s1h");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testParsingFailed() {
+        target.toNanoSeconds("1j40u");
+    }
+}


### PR DESCRIPTION
Convert a Golang Duration style sttring to a java Long (supports units: h (hour), m (minute), s (second).
Similar to: https://golang.org/pkg/time/#ParseDuration